### PR TITLE
3.1.7 updates from bc_working branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<jsoup.version>1.15.4</jsoup.version>
 		<jackson.version>2.18.2</jackson.version>
 		<guava.jre.version>33.3.1-jre</guava.jre.version>
-		<!--		<webdriver.manager.version>6.2.0</webdriver.manager.version>-->
+		<webdriver.manager.version>6.2.0</webdriver.manager.version>
 		<!--		<slf4j.version>2.0.16</slf4j.version>-->
 		<http.components.version>4.5.14</http.components.version>
 		<commons.io.version>2.18.0</commons.io.version>
@@ -319,7 +319,14 @@
 			<artifactId>log4j-api</artifactId>
 			<version>${log4j.version}</version>
 		</dependency>
-
+		
+		<!-- https://mvnrepository.com/artifact/io.github.bonigarcia/webdrivermanager-->
+		<dependency>
+			<groupId>io.github.bonigarcia</groupId>
+			<artifactId>webdrivermanager</artifactId>
+			<version>${webdriver.manager.version}</version>
+		</dependency>
+		
 		<!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
 		<dependency>
 			<groupId>org.hamcrest</groupId>
@@ -406,6 +413,10 @@
 				<exclusion>
 					<groupId>org.seleniumhq.selenium</groupId>
 					<artifactId>selenium-support</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.github.bonigarcia</groupId>
+					<artifactId>webdrivermanager</artifactId>
 				</exclusion>
 				
 			</exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.perfecto</groupId>
 	<artifactId>quantum</artifactId>
-	<version>3.1.6</version>
+	<version>3.1.7</version>
 	<packaging>jar</packaging>
 	<description>Quantum is QAF based open source project powered by Perforce</description>
 	<url>
@@ -23,6 +23,12 @@
 		<developer>
 			<name>Veronika Juhanson</name>
 			<email>vjuhanson@perforce.com</email>
+			<organization>Perfecto Mobile by Perforce</organization>
+			<organizationUrl>https://www.perfecto.io</organizationUrl>
+		</developer>
+		<developer>
+			<name>Brian Clark</name>
+			<email>bclark@perforce.com</email>
 			<organization>Perfecto Mobile by Perforce</organization>
 			<organizationUrl>https://www.perfecto.io</organizationUrl>
 		</developer>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<jsoup.version>1.15.4</jsoup.version>
 		<jackson.version>2.18.2</jackson.version>
 		<guava.jre.version>33.3.1-jre</guava.jre.version>
-		<webdriver.manager.version>6.2.0</webdriver.manager.version>
+		<webdriver.manager.version>6.1.0</webdriver.manager.version>
 		<!--		<slf4j.version>2.0.16</slf4j.version>-->
 		<http.components.version>4.5.14</http.components.version>
 		<commons.io.version>2.18.0</commons.io.version>

--- a/src/main/java/com/qmetry/qaf/automation/ui/webdriver/ElementMetaDataListener.java
+++ b/src/main/java/com/qmetry/qaf/automation/ui/webdriver/ElementMetaDataListener.java
@@ -162,11 +162,10 @@ public class ElementMetaDataListener extends QAFWebElementCommandAdapter {
 
 	@Override
 	public void onFailure(QAFExtendedWebElement element, CommandTracker commandTracker) {
-		System.out.println("Check Driver type");
+		// Updated to prevent executing javascript scroll in Native Appium executions
 		
 		String driverType = element.getWrappedDriver().getUnderLayingDriver().getClass().getCanonicalName();
-		System.out.println("Current Driver type: " + driverType);
-		String currentContext = "WEBVIEW";
+		String currentContext = "";
 		if(driverType.contains("Android")) {
 			 currentContext = AndroidDriver.class.cast(element.getWrappedDriver().getUnderLayingDriver()).getContext();
 		}else if(driverType.contains("IOS") ) {

--- a/src/main/java/com/qmetry/qaf/automation/ui/webdriver/ElementMetaDataListener.java
+++ b/src/main/java/com/qmetry/qaf/automation/ui/webdriver/ElementMetaDataListener.java
@@ -1,0 +1,219 @@
+package com.qmetry.qaf.automation.ui.webdriver;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DriverCommand;
+import org.openqa.selenium.remote.Response;
+
+import com.qmetry.qaf.automation.core.ConfigurationManager;
+
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+
+/**
+ * This listener provides capability of defining scroll behavior, encrypted
+ * value for password based on element on meta-data.
+ * <p>
+ * Examples:
+ * <ul>
+ * <li>{'locator':'name=q','scroll': 'OnFail','sendkeys-options': 'click clear','scroll-options': '{block: \'center\'}'}
+ * <li>{'locator':'name=pwdTxt','sendkeys-options': 'clear','type': 'password'}
+ * <li>{}
+ * </ul>
+ * 
+ * @since 2.1.13
+ * @author chirag.jayswal
+ *
+ */
+public class ElementMetaDataListener extends QAFWebElementCommandAdapter {
+	/**
+	 * meta-key to specify scroll behavior, possible values:
+	 * <ul>
+	 * <li>Always/true - always scroll before commands required scroll
+	 * <li>OnFail - retry with scroll on failure for commands required scroll
+	 * </ul>
+	 */
+	public static final String SCROLL = "scroll";
+
+	/**
+	 * meta-key to specify scroll options, A value that indicates the type of
+	 * the align::
+	 * <p>
+	 * Examples:
+	 * <ul>
+	 * <li>{'scroll-options': 'true'}
+	 * <li>{'scroll-options': 'false'}
+	 * <li>{'scroll-options': '{block: \'center\'}'}
+	 * </ul>
+	 * 
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+	 */
+	public static final String SCROLL_OPTIONS = "scroll-options";
+
+	/**
+	 * meta-key to specify one or more send-keys options, possible values:
+	 * <ul>
+	 * <li>click: to specify click before send-keys
+	 * <li>clear: to specify clear before send-keys
+	 * </ul>
+	 * Examples:
+	 * <ul>
+	 * <li>{'sendkeys-options': 'clear'}
+	 * <li>{'sendkeys-options': 'click'}
+	 * <li>{'sendkeys-options': 'click clear'}
+	 * </ul>
+	 */
+	public static final String SENDKEYS_OPTIONS = "sendkeys-options";
+
+	/**
+	 * meta-key for send-keys to specify element type, possible values:
+	 * <ul>
+	 * <li>password/encrypted - required to decode before send keys
+	 * <li>select - specify this is select (basic support only) with options and
+	 * choose option
+	 * </ul>
+	 * Examples:
+	 * <ul>
+	 * <li>{'type': 'password'}
+	 * <li>{'type': 'select'}
+	 * </ul>
+	 */
+	public static final String TYPE = "type";
+
+//	public static final List<String> COMMANDS_REQUIRES_SCROLL = Arrays.asList(DriverCommand.CLICK_ELEMENT,
+//			DriverCommand.SEND_KEYS_TO_ELEMENT, DriverCommand.CLICK, DriverCommand.CLICK_ELEMENT,
+//			DriverCommand.DOUBLE_CLICK, DriverCommand.MOVE_TO, DriverCommand.MOUSE_DOWN, DriverCommand.MOUSE_UP,
+//			DriverCommand.ELEMENT_SCREENSHOT);
+	public static final List<String> COMMANDS_REQUIRES_SCROLL = Arrays.asList(DriverCommand.CLICK_ELEMENT,
+			DriverCommand.SEND_KEYS_TO_ELEMENT,
+			DriverCommand.ELEMENT_SCREENSHOT);
+
+	@Override
+	public void beforeCommand(QAFExtendedWebElement element, CommandTracker commandTracker) {
+		boolean isScrollRequired = getScrollBehavoir(element).startsWith("A")
+				|| getScrollBehavoir(element).startsWith("T");
+		if (isScrollRequired && COMMANDS_REQUIRES_SCROLL.contains(commandTracker.getCommand())) {
+			scrollToElement(element);
+		}
+
+		processSendKeys(element, commandTracker);
+	}
+
+	private void processSendKeys(QAFExtendedWebElement element, CommandTracker commandTracker) {
+		if (DriverCommand.SEND_KEYS_TO_ELEMENT.equalsIgnoreCase(commandTracker.getCommand())) {
+			CharSequence[] values = ((CharSequence[]) commandTracker.getParameters().get("value"));
+
+			String sendkeysOpts = getSendkeysOptions(element);
+			if (sendkeysOpts.indexOf("CLICK") >= 0) {
+				element.click();
+			}
+			if (sendkeysOpts.indexOf("CLEAR") >= 0) {
+				element.clear();
+				if (values[0] == null || values[0].length() == 0) {
+					// request to have empty field, which is done with
+					// clear.....
+					commandTracker.setResponce(new Response());
+					return;
+				}
+			}
+			if (isEncrypted(element)) {
+				String encriptedPassword = values[0].toString();
+				//decrypt encrypted text
+				values[0] = ConfigurationManager.getBundle().getPasswordDecryptor()
+						.getDecryptedPassword(encriptedPassword);
+				Response response=element.executeWitoutLog(commandTracker.getCommand(), commandTracker.getParameters());
+				commandTracker.setResponce(response);
+				//reset encrypted text
+				values[0] =encriptedPassword;
+			} else if (isSelect(element)) {
+				String locateOptionBy = "byText";
+				List<WebElement> options = element.findElements(By.tagName("option"));
+				for (CharSequence value : values) {
+					String str = value.toString();
+					if (str.equalsIgnoreCase("byValue") || str.equalsIgnoreCase("byText")
+							|| str.equalsIgnoreCase("byIndex")) {
+						locateOptionBy = str;
+						continue;
+					}
+					for (int i = 0; i < options.size(); i++) {
+						WebElement option = options.get(i);
+						if (locateOptionBy.equalsIgnoreCase("byIndex")
+								&& String.valueOf(i).equalsIgnoreCase(value.toString())) {
+							element.executeScript("selectedIndex=" + i);
+						} else if (locateOptionBy.equalsIgnoreCase("byValue")
+								&& String.valueOf(str).equalsIgnoreCase(option.getAttribute("value"))) {
+							element.executeScript("selectedIndex=" + i);
+						} else if (locateOptionBy.equalsIgnoreCase("byValue")
+								&& String.valueOf(str).equalsIgnoreCase(option.getText())) {
+							element.executeScript("selectedIndex=" + i);
+						}
+					}
+				}
+				// done using js
+				commandTracker.setResponce(new Response());
+			}
+		}
+
+	}
+
+	@Override
+	public void onFailure(QAFExtendedWebElement element, CommandTracker commandTracker) {
+		System.out.println("Check Driver type");
+		
+		String driverType = element.getWrappedDriver().getUnderLayingDriver().getClass().getCanonicalName();
+		System.out.println("Current Driver type: " + driverType);
+		String currentContext = "WEBVIEW";
+		if(driverType.contains("Android")) {
+			 currentContext = AndroidDriver.class.cast(element.getWrappedDriver().getUnderLayingDriver()).getContext();
+		}else if(driverType.contains("IOS") ) {
+			currentContext = IOSDriver.class.cast(element.getWrappedDriver().getUnderLayingDriver()).getContext();
+		}
+		if(!currentContext.contains("NATIVE")) {
+			boolean isScrollRequired = getScrollBehavoir(element).startsWith("O");
+			if (isScrollRequired && COMMANDS_REQUIRES_SCROLL.contains(commandTracker.getCommand()) && element.isPresent()) {
+				scrollToElement(element);
+				commandTracker.setRetry(true);
+			
+			}
+		}	//Else Do Not attempt javascript scrollToElement!
+	}
+
+	private void scrollToElement(QAFExtendedWebElement element) {
+		element.executeScript("scrollIntoView(" + getScrollOptions(element) + ");");
+		// element.getWrappedDriver().executeScript(
+		// "arguments[0].scrollIntoView(false);arguments[0].scrollIntoView({block:
+		// 'center'});", element);
+	}
+
+	private String getScrollBehavoir(QAFExtendedWebElement element) {
+		return element.getMetaData().containsKey(SCROLL) ? element.getMetaData().get(SCROLL).toString().toUpperCase()
+				: "";
+	}
+
+	private String getScrollOptions(QAFExtendedWebElement element) {
+		return element.getMetaData().containsKey(SCROLL_OPTIONS) ? element.getMetaData().get(SCROLL_OPTIONS).toString()
+				: "";
+	}
+
+	private String getSendkeysOptions(QAFExtendedWebElement element) {
+		return element.getMetaData().containsKey(SENDKEYS_OPTIONS)
+				? element.getMetaData().get(SENDKEYS_OPTIONS).toString().toUpperCase() : "";
+	}
+
+	private boolean isEncrypted(QAFExtendedWebElement element) {
+		return element.getMetaData().containsKey(TYPE)
+				&& (element.getMetaData().get(TYPE).toString().toUpperCase().startsWith("P")
+						|| element.getMetaData().get(TYPE).toString().toUpperCase().startsWith("E"));
+	}
+
+	private boolean isSelect(QAFExtendedWebElement element) {
+		return element.getMetaData().containsKey(TYPE)
+				&& element.getMetaData().get(TYPE).toString().toUpperCase().startsWith("S");
+	}
+
+}
+

--- a/src/main/java/com/quantum/listeners/FailedTestSuite.java
+++ b/src/main/java/com/quantum/listeners/FailedTestSuite.java
@@ -218,7 +218,7 @@ public class FailedTestSuite {
 			return;
 		}
 		
-		if(failedTestSuite.failedTests.size()>0) {
+		if((ConfigurationManager.getBundle().getString("generate.failed.testng.file", "true") == "true") && failedTestSuite.failedTests.size()>0) {
 			
 			failedTestSuite.addAllFailedTests();
 			
@@ -259,6 +259,8 @@ public class FailedTestSuite {
 			} catch (ParserConfigurationException e1) {
 				e1.printStackTrace();
 			}
+		}else {
+			logger.info("Quantum Failed TestNG Xml file NOT generated because no failed tests OR 'generate.failed.testng.file' parameter was not set to true ");
 		}
 	}
 


### PR DESCRIPTION
Includes the following updates:

1. Minor update to grant the ability to turn off generating the failed test testng file by referencing a new parameter called _generate.failed.testng.file_
2. Updated webdrivermanager dependency to v 6.1.0 to remove identified vulnerability 
3. Pulled in and modified the ElementMetaDataListener from QAF to modify the onFailure method to handle the case where there is a retry using javascript to scrollToElement that is not relevant for Appium-based native context conditions.